### PR TITLE
Fix multiple definitions of `verbose'

### DIFF
--- a/test-cert.c
+++ b/test-cert.c
@@ -32,8 +32,6 @@
 
 #include "extern.h"
 
-int	 verbose;
-
 static void
 cert_print(const struct cert *p)
 {

--- a/test-mft.c
+++ b/test-mft.c
@@ -29,8 +29,6 @@
 
 #include "extern.h"
 
-int	 verbose;
-
 static void
 mft_print(const struct mft *p)
 {

--- a/test-roa.c
+++ b/test-roa.c
@@ -29,8 +29,6 @@
 
 #include "extern.h"
 
-int	verbose;
-
 static void
 roa_print(const struct roa *p)
 {

--- a/test-tal.c
+++ b/test-tal.c
@@ -29,8 +29,6 @@
 
 #include "extern.h"
 
-int	verbose;
-
 static void
 tal_print(const struct tal *p)
 {


### PR DESCRIPTION
This should fix #16, at least it builds properly now on GCC 8, 9 and 10.